### PR TITLE
fix: 修复 Syncmatica 修改状态清理时的空值写入问题

### DIFF
--- a/lophine-server/src/main/java/org/leavesmc/leaves/protocol/syncmatica/CommunicationManager.java
+++ b/lophine-server/src/main/java/org/leavesmc/leaves/protocol/syncmatica/CommunicationManager.java
@@ -28,6 +28,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.Mirror;
 import net.minecraft.world.level.block.Rotation;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.leavesmc.leaves.protocol.core.LeavesProtocol;
 import org.leavesmc.leaves.protocol.core.ProtocolHandler;
 import org.leavesmc.leaves.protocol.syncmatica.exchange.*;
@@ -351,8 +352,12 @@ public class CommunicationManager implements LeavesProtocol {
         return downloadState.getOrDefault(syncmatic.getHash(), false);
     }
 
-    public static void setModifier(final @NotNull ServerPlacement syncmatic, final Exchange exchange) {
-        modifyState.put(syncmatic.getHash(), exchange);
+    public static void setModifier(final @NotNull ServerPlacement syncmatic, final @Nullable Exchange exchange) {
+        if (exchange == null) {
+            modifyState.remove(syncmatic.getHash());
+        } else {
+            modifyState.put(syncmatic.getHash(), exchange);
+        }
     }
 
     public static Exchange getModifier(final @NotNull ServerPlacement syncmatic) {


### PR DESCRIPTION
### 变更说明

本 PR 修复 Syncmatica 协议在清理 placement modifier 状态时，可能向 `ConcurrentHashMap` 写入 `null` 导致服务端抛出 `NullPointerException` 的问题。

`ModifyExchangeServer#onClose()` 在关闭修改交换时，会通过 `CommunicationManager#setModifier(placement, null)` 清理当前 modifier。原实现直接调用：

```java
modifyState.put(syncmatic.getHash(), exchange);
```

由于 `modifyState` 是 `ConcurrentHashMap`，不允许 `null` value，因此玩家在 Syncmatica modify exchange 过程中断开连接时，可能触发：

```text
ConcurrentHashMap.putVal
ConcurrentHashMap.put
CommunicationManager.setModifier
ModifyExchangeServer.onClose
AbstractExchange.close
CommunicationManager.onPlayerLeave
```

最终导致 Region tick failure。

### 修复方式

当 `setModifier()` 收到 `null` exchange 时，改为从 `modifyState` 中移除对应 placement 的 modifier 状态：

```java
if (exchange == null) {
    modifyState.remove(syncmatic.getHash());
} else {
    modifyState.put(syncmatic.getHash(), exchange);
}
```

同时将参数标注为 `@Nullable`，使方法签名与实际调用语义一致。

### 影响范围

本次修改仅调整 Syncmatica modifier 状态的清理逻辑，不改变正常 modify exchange 的创建、接受、完成流程。

### 验证方式

1. 编译项目。
2. 开启 `function.protocol.syncmatica.enabled = true`。
3. 让客户端发起或参与 Syncmatica placement modify exchange。
4. 在 exchange 未完成或刚完成时断开连接。
5. 预期不再出现 `ConcurrentHashMap.putVal -> CommunicationManager.setModifier` 相关 NPE。
`