### PR TITLE
fix: 修复Folia waypoint定位条可能导致客户端崩溃的问题

### DIFF
--- a/lophine-server/luminol-patches/features/0007-Fix-Folia-waypoint-connection-ordering.patch
+++ b/lophine-server/luminol-patches/features/0007-Fix-Folia-waypoint-connection-ordering.patch
@@ -1,0 +1,193 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: xiaoyueyoqwq <xiaoyueyoqwq@users.noreply.github.com>
+Date: Fri, 24 Apr 2026 18:03:33 +0800
+Subject: [PATCH] Fix Folia waypoint connection ordering
+
+
+diff --git a/src/main/java/me/earthme/luminol/utils/FoliaServerWaypointManager.java b/src/main/java/me/earthme/luminol/utils/FoliaServerWaypointManager.java
+index 0e6c9edbceef525bf102ad8f1fc0cb08e789d0e6..f3e7a84cbb0c25ceabc2617c32c3164d545e7620 100755
+--- a/src/main/java/me/earthme/luminol/utils/FoliaServerWaypointManager.java
++++ b/src/main/java/me/earthme/luminol/utils/FoliaServerWaypointManager.java
+@@ -19,6 +19,7 @@ public class FoliaServerWaypointManager implements WaypointManager<@NotNull Wayp
+     private final Set<WaypointTransmitter> waypoints = ConcurrentHashMap.newKeySet();
+     private final Set<ServerPlayer> trackingPlayers = ConcurrentHashMap.newKeySet();
+     private final Map<ServerPlayer, Map<WaypointTransmitter, WaypointTransmitter.Connection>> connections = new ConcurrentHashMap<>();
++    private final Map<ServerPlayer, Set<WaypointTransmitter>> pendingConnections = new ConcurrentHashMap<>();
+ 
+     public void breakAllConnections() {
+         throw new UnsupportedOperationException("Unused");
+@@ -45,7 +46,9 @@ public class FoliaServerWaypointManager implements WaypointManager<@NotNull Wayp
+         }
+         // Leaves end - fakeplayer
+ 
+-        this.waypoints.add(waypoint);
++        if (!this.waypoints.add(waypoint)) {
++            return;
++        }
+ 
+         for (ServerPlayer toCreateFor : this.trackingPlayers) {
+             this.createConnection(toCreateFor, waypoint);
+@@ -92,6 +95,10 @@ public class FoliaServerWaypointManager implements WaypointManager<@NotNull Wayp
+             }
+         }
+ 
++        for (Set<WaypointTransmitter> pendingConnectionsOfCurr : this.pendingConnections.values()) {
++            pendingConnectionsOfCurr.remove(waypoint);
++        }
++
+         this.waypoints.remove(waypoint);
+     }
+ 
+@@ -122,7 +129,12 @@ public class FoliaServerWaypointManager implements WaypointManager<@NotNull Wayp
+             return;
+         }
+ 
+-        Sets.SetView<WaypointTransmitter> set = Sets.difference(this.waypoints, connectionsOfCurr.keySet());
++        Set<WaypointTransmitter> pendingConnectionsOfCurr = this.pendingConnections.get(player);
++        Set<WaypointTransmitter> knownWaypoints = Sets.union(
++                connectionsOfCurr.keySet(),
++                pendingConnectionsOfCurr == null ? Set.of() : pendingConnectionsOfCurr
++        );
++        Sets.SetView<WaypointTransmitter> set = Sets.difference(this.waypoints, knownWaypoints);
+ 
+         for (Map.Entry<WaypointTransmitter, WaypointTransmitter.Connection> entry : connectionsOfCurr.entrySet()) {
+             this.updateConnection(player, entry.getKey(), entry.getValue());
+@@ -135,6 +147,7 @@ public class FoliaServerWaypointManager implements WaypointManager<@NotNull Wayp
+ 
+     public void removePlayer(ServerPlayer player) {
+         final Map<WaypointTransmitter, WaypointTransmitter.Connection> removedConnections = this.connections.remove(player);
++        this.pendingConnections.remove(player);
+ 
+         if (removedConnections != null) {
+             for (WaypointTransmitter.Connection connection : removedConnections.values()) {
+@@ -171,14 +184,45 @@ public class FoliaServerWaypointManager implements WaypointManager<@NotNull Wayp
+     private void createConnection(ServerPlayer player, WaypointTransmitter waypoint) {
+         if (player != waypoint) {
+             if (isLocatorBarEnabledFor(player)) {
+-                // -> waypoint
+-                scheduleIfOffTarget(waypoint, () -> waypoint.makeWaypointConnectionWith(player).ifPresentOrElse(connection -> {
+-                    final Map<WaypointTransmitter, WaypointTransmitter.Connection> connectionsOfThisPlayer = this.connections.computeIfAbsent(player, o -> new ConcurrentHashMap<>());
++                if (!this.trackingPlayers.contains(player) || !this.waypoints.contains(waypoint)) {
++                    return;
++                }
+ 
+-                    connectionsOfThisPlayer.put(waypoint, connection);
++                Map<WaypointTransmitter, WaypointTransmitter.Connection> existingConnections = this.connections.get(player);
++                if (existingConnections != null && existingConnections.containsKey(waypoint)) {
++                    return;
++                }
+ 
+-                    scheduleIfOffTarget((Entity) player, connection::connect);
++                if (!this.markConnectionPending(player, waypoint)) {
++                    return;
++                }
++
++                // -> waypoint
++                scheduleIfOffTarget(waypoint, () -> waypoint.makeWaypointConnectionWith(player).ifPresentOrElse(connection -> {
++                    scheduleIfOffTarget((Entity) player, () -> {
++                        try {
++                            if (!this.isPendingConnection(player, waypoint)) {
++                                return;
++                            }
++
++                            if (!CommandConfig.waypointsAndWaypointCommand || !this.trackingPlayers.contains(player) || !this.waypoints.contains(waypoint) || !isLocatorBarEnabledFor(player)) {
++                                return;
++                            }
++
++                            final Map<WaypointTransmitter, WaypointTransmitter.Connection> connectionsOfThisPlayer = this.connections.computeIfAbsent(player, o -> new ConcurrentHashMap<>());
++                            if (connectionsOfThisPlayer.containsKey(waypoint)) {
++                                return;
++                            }
++
++                            connection.connect();
++                            connectionsOfThisPlayer.put(waypoint, connection);
++                        } finally {
++                            this.clearConnectionPending(player, waypoint);
++                        }
++                    });
+                 }, () -> {
++                    this.clearConnectionPending(player, waypoint);
++
+                     final Map<WaypointTransmitter, WaypointTransmitter.Connection> connectionsOfThisPlayer = this.connections.get(player);
+ 
+                     if (connectionsOfThisPlayer != null) {
+@@ -196,6 +240,11 @@ public class FoliaServerWaypointManager implements WaypointManager<@NotNull Wayp
+         if (player != waypoint) {
+             if (isLocatorBarEnabledFor(player)) {
+                 scheduleIfOffTarget((Entity) player, () -> {
++                    Map<WaypointTransmitter, WaypointTransmitter.Connection> currentConnections = this.connections.get(player);
++                    if (currentConnections == null || currentConnections.get(waypoint) != connection) {
++                        return;
++                    }
++
+                     if (!connection.isBroken()) {
+                         connection.update();
+                     } else {
+@@ -206,30 +255,32 @@ public class FoliaServerWaypointManager implements WaypointManager<@NotNull Wayp
+                             };
+ 
+                             waypoint.makeWaypointConnectionWith(player).ifPresentOrElse(connection1 -> {
+-                                final Map<WaypointTransmitter, WaypointTransmitter.Connection> connectionsOfThisPlayer = this.connections.computeIfAbsent(player, o -> new ConcurrentHashMap<>());
+-
+-                                connectionsOfThisPlayer.put(waypoint, connection1);
+-
+-
+                                 ref.target = connection1;
+                                 ref.connectionOrDisconnect = true;
+                             }, () -> {
+-                                final Map<WaypointTransmitter, WaypointTransmitter.Connection> connectionsOfThisPlayer = this.connections.get(player);
+-
+-                                if (connectionsOfThisPlayer != null) {
+-                                    connectionsOfThisPlayer.remove(waypoint);
+-                                }
+-
+                                 ref.target = connection;
+                                 ref.connectionOrDisconnect = false;
+                             });
+ 
+                             scheduleIfOffTarget((Entity) player, () -> {
++                                Map<WaypointTransmitter, WaypointTransmitter.Connection> connectionsOfThisPlayer = this.connections.get(player);
++                                if (connectionsOfThisPlayer == null || connectionsOfThisPlayer.get(waypoint) != connection) {
++                                    return;
++                                }
++
+                                 if (ref.connectionOrDisconnect) {
++                                    if (!CommandConfig.waypointsAndWaypointCommand || !this.trackingPlayers.contains(player) || !this.waypoints.contains(waypoint) || !isLocatorBarEnabledFor(player)) {
++                                        connectionsOfThisPlayer.remove(waypoint, connection);
++                                        connection.disconnect();
++                                        return;
++                                    }
++
+                                     ref.target.connect();
++                                    connectionsOfThisPlayer.replace(waypoint, connection, ref.target);
+                                     return;
+                                 }
+ 
++                                connectionsOfThisPlayer.remove(waypoint, connection);
+                                 ref.target.disconnect();
+                             });
+                         });
+@@ -238,4 +289,23 @@ public class FoliaServerWaypointManager implements WaypointManager<@NotNull Wayp
+             }
+         }
+     }
++
++    private boolean markConnectionPending(ServerPlayer player, WaypointTransmitter waypoint) {
++        return this.pendingConnections.computeIfAbsent(player, unused -> ConcurrentHashMap.newKeySet()).add(waypoint);
++    }
++
++    private boolean isPendingConnection(ServerPlayer player, WaypointTransmitter waypoint) {
++        Set<WaypointTransmitter> pendingConnectionsOfPlayer = this.pendingConnections.get(player);
++        return pendingConnectionsOfPlayer != null && pendingConnectionsOfPlayer.contains(waypoint);
++    }
++
++    private void clearConnectionPending(ServerPlayer player, WaypointTransmitter waypoint) {
++        Set<WaypointTransmitter> pendingConnectionsOfPlayer = this.pendingConnections.get(player);
++        if (pendingConnectionsOfPlayer != null) {
++            pendingConnectionsOfPlayer.remove(waypoint);
++            if (pendingConnectionsOfPlayer.isEmpty()) {
++                this.pendingConnections.remove(player, pendingConnectionsOfPlayer);
++            }
++        }
++    }
+ }


### PR DESCRIPTION
## 概述

该 PR 尝试修复 [Folia/Luminol waypoint 管理器在跨 region 调度下可能出现的连接状态顺序问题](https://github.com/LuminolMC/Luminol/issues/185#issuecomment-4289878260)

根据测试服日志，玩家加入后存在以下异常状态：

- 同一个 player/waypoint pair 被重复创建 connection
- connection 在 `connect()` 发送 add 包之前已经被放入 `connections` map
- 后续 update 路径可能把该 connection 误判为“客户端已经收到 add”
- 因此服务端可能在客户端收到 waypoint add 之前先发送 waypoint update

该顺序问题可能导致客户端 waypoint 状态机异常，表现为客户端崩溃或断开连接。

## 修改内容

- 为 `FoliaServerWaypointManager` 增加 `pendingConnections`
  - 正在创建但尚未发送 add 的 connection 不再提前进入 `connections`
  - 避免 update 路径对未完成 add 的 connection 发送 update
- `trackWaypoint()` 对已存在的 waypoint 直接跳过
  - 避免重复创建同一个 waypoint 的连接
- `createConnection()` 增加状态检查
  - player 仍在 tracking
  - waypoint 仍被 tracked
  - locator bar 仍启用
  - 同一 pair 没有已存在 connection
  - 同一 pair 没有 pending connection
- `updateConnection()` 增加 stale connection 检查
  - 发送 update/remake 前确认 map 中当前 connection 仍然是该对象
  - 避免旧的跨 region 调度任务覆盖较新的连接状态
- `untrackWaypoint()` / `removePlayer()` 清理 pending 状态

> [!WARNING]
> **该修复仍然处于试验阶段。**
> 
> Waypoint 在 Folia 多 region 环境下涉及跨线程调度、实体生命周期、玩家加入/退出、waypoint add/update/remove 顺序等多个边界条件。虽然目前日志证据显示该 PR 命中了一个明确的 update-before-add 窗口，但仍可能存在未覆盖的情况，包括但不限于：
>
> - 特定玩家加入/退出时序下的 waypoint 丢失
> - locator bar 开关变化时的连接状态不同步
>- broken connection remake 路径中的边界问题
>- 其他客户端或服务端实现差异导致的不确定行为
>
>**因此该 PR 应视为一次有针对性的实验性修复，而不是已经完全证明无风险的最终方案。**
>
>如果合并或测试后出现新的 waypoint 相关问题**将由我积极跟进修复**

## 本地验证

已在本地执行并通过：

- `./gradlew applyAllPatches`
- `./gradlew lophine-server:compileJava`
- `./gradlew lophine-server:createMojmapPaperclipJar`

同时已使用生成的 mojmap paperclip jar 作为后续测试包。
